### PR TITLE
Fix participant-side protocol.

### DIFF
--- a/src/nft_swapper/State.mo
+++ b/src/nft_swapper/State.mo
@@ -7,11 +7,7 @@ import Array "mo:base/Array";
 module {
   public type Plan = Types.Plan;
   public type PlanState = Types.PlanState.PlanState;
-
-  public type PlanStates = {
-    past : [PlanState];
-    current : PlanState;
-  };
+  public type PlanStates = Types.PlanState.PlanStates;
 
   public type State = {
     installer : Principal;

--- a/src/nft_swapper/Types.mo
+++ b/src/nft_swapper/Types.mo
@@ -94,7 +94,12 @@ module {
       #invalid : Invalid;
       #cancelled : Cancelled;
       #complete : Complete;
-    }
+    };
+
+    public type PlanStates = {
+      past : [PlanState];
+      current : PlanState;
+    };
 
   };
 };

--- a/src/nft_swapper/Types.mo
+++ b/src/nft_swapper/Types.mo
@@ -101,5 +101,17 @@ module {
       current : PlanState;
     };
 
+    public func planIsBeingSubmitted(ps : ?PlanStates) : Bool {
+      switch (ps) {
+        case null true;
+        case (?ps) {
+          switch (ps.current) {
+            case (#submit(_)) { true };
+            case _ { false };
+          };
+        };
+      };
+    };
+
   };
 };

--- a/src/nft_swapper/Types.mo
+++ b/src/nft_swapper/Types.mo
@@ -113,5 +113,17 @@ module {
       };
     };
 
+    public func planIsResourcing(ps : ?PlanStates) : Bool {
+      switch (ps) {
+        case null false;
+        case (?ps) {
+          switch (ps.current) {
+            case (#resourcing(_)) { true };
+            case _ { false };
+          };
+        };
+      };
+    };
+
   };
 };

--- a/test/NftSwap2Simple.test.mo
+++ b/test/NftSwap2Simple.test.mo
@@ -62,7 +62,7 @@ let bobsPart = async {
   // Bob does this stuff:
   assert swapper.submitPlan(bob, thePlan);
   // wait until plan is resourcing.
-  while (planIsBeingSubmitted(swapper.getPlan(alice, thePlan))) {
+  while (planIsBeingSubmitted(swapper.getPlan(bob, thePlan))) {
     await async {};
   };
   assert (await c2.installerSend(#nft "baboon13", swapperPrincipal)); // to do -- bob sends.

--- a/test/NftSwap2Simple.test.mo
+++ b/test/NftSwap2Simple.test.mo
@@ -52,9 +52,9 @@ let alicesPart = async { // Alice does this stuff:
 };
 
 let bobsPart = async { // Bob does this stuff:
-    assert (await c2.installerSend(#nft "baboon13", swapperPrincipal)); // to do -- bob sends.
-    // to do -- wait until plan is resourcing.
     assert swapper.submitPlan(bob, thePlan);
+    // to do -- wait until plan is resourcing.
+    assert (await c2.installerSend(#nft "baboon13", swapperPrincipal)); // to do -- bob sends.
     D.print (debug_show swapper.getPlan(bob, thePlan));
     assert (await swapper.notifyPlan(bob, thePlan, on2)); // plan executes here (assuming this happens after Alice).
 };

--- a/test/NftSwap2Simple.test.mo
+++ b/test/NftSwap2Simple.test.mo
@@ -5,7 +5,7 @@ import NftSwapper "../src/nft_swapper/Core";
 import NftSwapperTypes "../src/nft_swapper/Types";
 import D "mo:base/Debug";
 
-type PlanStates = NftSwapperTypes.PlanState.PlanStates;
+let planIsBeingSubmitted = NftSwapperTypes.PlanState.planIsBeingSubmitted;
 
 let alice = Principal.fromText("rkp4c-7iaaa-aaaaa-aaaca-cai");
 let bob = Principal.fromText("renrk-eyaaa-aaaaa-aaada-cai");
@@ -45,18 +45,6 @@ let thePlan = {
 };
 
 // send resources to plan (via swapper)
-
-func planIsBeingSubmitted(ps : ?PlanStates) : Bool {
-  switch (ps) {
-    case null true;
-    case (?ps) {
-      switch (ps.current) {
-        case (#submit(_)) { true };
-        case _ { false };
-      };
-    };
-  };
-};
 
 let alicesPart = async {
   // Alice does this stuff:

--- a/test/NftSwap2Simple.test.mo
+++ b/test/NftSwap2Simple.test.mo
@@ -41,13 +41,11 @@ let thePlan = {
     ];
 };
 
-assert swapper.submitPlan(alice, thePlan);
-assert swapper.submitPlan(bob, thePlan); // now plan is "resourcing"
-
-
 // send resources to plan (via swapper)
 
 let alicesPart = async { // Alice does this stuff:
+    assert swapper.submitPlan(alice, thePlan);
+    // to do -- wait until plan is resourcing.
     assert (await c1.installerSend(#nft "ape42", swapperPrincipal)); // to do -- alice sends.
     D.print (debug_show swapper.getPlan(alice, thePlan));
     assert (await swapper.notifyPlan(alice, thePlan, on1));    
@@ -55,6 +53,8 @@ let alicesPart = async { // Alice does this stuff:
 
 let bobsPart = async { // Bob does this stuff:
     assert (await c2.installerSend(#nft "baboon13", swapperPrincipal)); // to do -- bob sends.
+    // to do -- wait until plan is resourcing.
+    assert swapper.submitPlan(bob, thePlan);
     D.print (debug_show swapper.getPlan(bob, thePlan));
     assert (await swapper.notifyPlan(bob, thePlan, on2)); // plan executes here (assuming this happens after Alice).
 };

--- a/test/NftSwap2Simple.test.mo
+++ b/test/NftSwap2Simple.test.mo
@@ -6,6 +6,7 @@ import NftSwapperTypes "../src/nft_swapper/Types";
 import D "mo:base/Debug";
 
 let planIsBeingSubmitted = NftSwapperTypes.PlanState.planIsBeingSubmitted;
+let planIsResourcing = NftSwapperTypes.PlanState.planIsResourcing;
 
 let alice = Principal.fromText("rkp4c-7iaaa-aaaaa-aaaca-cai");
 let bob = Principal.fromText("renrk-eyaaa-aaaaa-aaada-cai");
@@ -49,10 +50,14 @@ let thePlan = {
 let alicesPart = async {
   // Alice does this stuff:
   assert swapper.submitPlan(alice, thePlan);
+
   // wait until plan is resourcing.
   while (planIsBeingSubmitted(swapper.getPlan(alice, thePlan))) {
+    // To do -- Tell Alice things as we wait.
     await async {}; // NB: Need this, to yeild control to other block, below.
   };
+  if (not planIsResourcing(swapper.getPlan(alice, thePlan))) { assert false };
+
   assert (await c1.installerSend(#nft "ape42", swapperPrincipal)); // to do -- alice sends.
   D.print(debug_show swapper.getPlan(alice, thePlan));
   assert (await swapper.notifyPlan(alice, thePlan, on1));
@@ -61,10 +66,14 @@ let alicesPart = async {
 let bobsPart = async {
   // Bob does this stuff:
   assert swapper.submitPlan(bob, thePlan);
+
   // wait until plan is resourcing.
   while (planIsBeingSubmitted(swapper.getPlan(bob, thePlan))) {
+    // To do -- Tell Bob things as we wait.
     await async {};
   };
+  if (not planIsResourcing(swapper.getPlan(alice, thePlan))) { assert false };
+
   assert (await c2.installerSend(#nft "baboon13", swapperPrincipal)); // to do -- bob sends.
   D.print(debug_show swapper.getPlan(bob, thePlan));
   assert (await swapper.notifyPlan(bob, thePlan, on2)); // plan executes here (assuming this happens after Alice).


### PR DESCRIPTION
Refines the parts of each party in their side of the protocol:
- [x] Each party does the `submit` as part of their side.
- [x] Each party waits for the other to finish submitting before continuing.
- [x] Each party checks for `#resourcing` before sending or notifying.