### PR TITLE
Common code: `ArraySet`

### DIFF
--- a/src/common/ArraySet.mo
+++ b/src/common/ArraySet.mo
@@ -13,6 +13,9 @@ module {
     };
 
     public func add(x : X) : [X] {
+      // to preserve set invariants (each element appears at most once),
+      // this operation only makes sense after testing isMember and getting false.
+      // we rely on the caller doing this.
       let size = elements.size();
       Array.tabulate<X>(
         size + 1,

--- a/src/common/ArraySet.mo
+++ b/src/common/ArraySet.mo
@@ -1,0 +1,37 @@
+import Array "mo:base/Array";
+import Option "mo:base/Option";
+
+module {
+  public func empty<X>() : [X] { [] };
+
+  // A smallish immutable set represented with an immutable array.
+  public class ArraySet<X>(elements : [X], eq : (X, X) -> Bool) {
+    public func array() : [X] { elements };
+
+    public func isMember(x : X) : Bool {
+      Option.isSome(Array.find<X>(elements, func(y : X) : Bool { eq(x, y) }));
+    };
+
+    public func add(x : X) : [X] {
+      let size = elements.size();
+      Array.tabulate<X>(
+        size + 1,
+        func i {
+          if (i < size) {
+            elements[i];
+          } else {
+            x;
+          };
+        },
+      );
+    };
+  };
+
+  public func principalSet(ps : [Principal]) : ArraySet<Principal> {
+    ArraySet(
+      ps,
+      func(p1 : Principal, p2 : Principal) : Bool { p1 == p2 },
+    );
+  };
+
+};

--- a/src/common/ArraySet.mo
+++ b/src/common/ArraySet.mo
@@ -8,7 +8,7 @@ module {
   public class ArraySet<X>(elements : [X], eq : (X, X) -> Bool) {
     public func array() : [X] { elements };
 
-    public func isMember(x : X) : Bool {
+    public func has(x : X) : Bool {
       Option.isSome(Array.find<X>(elements, func(y : X) : Bool { eq(x, y) }));
     };
 
@@ -27,6 +27,18 @@ module {
           };
         },
       );
+    };
+
+    // Order does not matter.
+    public func equals(ys : [X]) : Bool {
+      let other = ArraySet(ys, eq);
+      for (x in elements.vals()) {
+        if (not (other.has(x))) { return false };
+      };
+      for (y in ys.vals()) {
+        if (not (has(y))) { return false };
+      };
+      return true;
     };
   };
 

--- a/src/nft_swapper/Types.mo
+++ b/src/nft_swapper/Types.mo
@@ -5,12 +5,8 @@ import Trie "mo:base/Trie";
 
 module {
 
-  // An NFT ID
-  // with a collection service
-  // where that ID makes sense.
   public type Nft = NCTypes.Nft;
 
-  // An NFT with an attached ownership assertion.
   public type OwnedNft = {
     owner : Principal;
     nft : Nft;
@@ -22,8 +18,6 @@ module {
     nft : Nft;
   };
 
-  // A plan is a sequence of two-way swaps.
-  // It is valid if run as a sequence, it is valid.
   public type Plan = {
     sends : [Send];
   };
@@ -54,7 +48,7 @@ module {
   // States of a "flow" through
   // the Swapper multi-canister protocol.
   public module PlanState {
-    // 1. One or more parties
+    // One or more parties
     // have submitted a plan.
     public type Submit = {
       plan : Plan;

--- a/test/NftSwap3.test.mo
+++ b/test/NftSwap3.test.mo
@@ -10,21 +10,28 @@ let planIsResourcing = NftSwapperTypes.PlanState.planIsResourcing;
 
 let alice = Principal.fromText("rkp4c-7iaaa-aaaaa-aaaca-cai");
 let bob = Principal.fromText("renrk-eyaaa-aaaaa-aaada-cai");
+let chuck = Principal.fromText("rno2w-sqaaa-aaaaa-aaacq-cai");
+
 let installer = Principal.fromText("rno2w-sqaaa-aaaaa-aaacq-cai");
 let swapperPrincipal = Principal.fromText("rno2w-sqaaa-aaaaa-aaacq-cai");
 
 // Two collections, c1 and c2
 let c1 = await NftCollection();
 let c2 = await NftCollection();
+let c3 = await NftCollection();
 
 assert await c1.create(#nft "ape42", alice);
 assert await c2.create(#nft "baboon13", bob);
+assert await c3.create(#nft "alien51", bob);
 
 let n1 = { id = #nft "ape42"; collection = Principal.fromActor(c1) };
 let on1 = { owner = alice; nft = n1 };
 
 let n2 = { id = #nft "baboon13"; collection = Principal.fromActor(c2) };
 let on2 = { owner = bob; nft = n2 };
+
+let n3 = { id = #nft "alien51"; collection = Principal.fromActor(c3) };
+let on3 = { owner = chuck; nft = n3 };
 
 let swapper = NftSwapper.Core(installer, State.init(installer));
 
@@ -38,6 +45,11 @@ let thePlan = {
     {
       source = bob;
       nft = n2;
+      target = chuck;
+    },
+    {
+      source = chuck;
+      nft = n3;
       target = alice;
     },
   ];
@@ -77,12 +89,30 @@ let bobsPart = async {
   assert (await swapper.notifyPlan(bob, thePlan, on2)); // plan executes here (assuming this happens after Alice).
 };
 
+let chucksPart = async {
+  // Chuck does this stuff:
+  assert swapper.submitPlan(chuck, thePlan);
+
+  // wait until plan is resourcing.
+  while (planIsBeingSubmitted(swapper.getPlan(chuck, thePlan))) {
+    // To do -- Tell Bob things as we wait.
+    await async {};
+  };
+  if (not planIsResourcing(swapper.getPlan(chuck, thePlan))) { assert false };
+
+  assert (await c3.installerSend(#nft "alien51", swapperPrincipal)); // to do -- bob sends.
+  D.print(debug_show swapper.getPlan(chuck, thePlan));
+  assert (await swapper.notifyPlan(chuck, thePlan, on3)); // plan executes here (assuming this happens after Alice).
+};
+
 await alicesPart;
 await bobsPart;
+await chucksPart;
 
 let p = swapper.getPlan(swapperPrincipal, thePlan);
 
 // to do --assert that plan p is #complete
 
 assert (await c1.getOwner(#nft "ape42")) == ?bob;
-assert (await c2.getOwner(#nft "baboon13")) == ?alice;
+assert (await c2.getOwner(#nft "baboon13")) == ?chuck;
+assert (await c3.getOwner(#nft "alien51")) == ?alice;


### PR DESCRIPTION
`ArraySet` gives a useful abstraction that's partly OO and partly functional/pure.

We often want to take a smallish array and treat its elements like a set.

This PR extracts that pattern, gives it a name, and applies the abstraction to the code we hade, making it more readable.

This PR also generalizes the Swapper `Core` logic to work with any number of parties, not merely two.